### PR TITLE
don't add creator as admin by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Terraform Module to set up an AWS EKS cluster.
 | <a name="input_enable_aws_eso_role"></a> [enable\_aws\_eso\_role](#input\_enable\_aws\_eso\_role) | Determines whether to install External Secrets Operator IRSA | `bool` | `false` | no |
 | <a name="input_enable_aws_load_balancer_controller_role"></a> [enable\_aws\_load\_balancer\_controller\_role](#input\_enable\_aws\_load\_balancer\_controller\_role) | Determines whether to install AWS Load Balancer Controller IRSA | `bool` | `false` | no |
 | <a name="input_enable_cluster_autoscaler_role"></a> [enable\_cluster\_autoscaler\_role](#input\_enable\_cluster\_autoscaler\_role) | Determines whether to install Cluster Autoscaler IRSA | `bool` | `false` | no |
+| <a name="input_enable_cluster_creator_admin_permissions"></a> [enable\_cluster\_creator\_admin\_permissions](#input\_enable\_cluster\_creator\_admin\_permissions) | Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry | `bool` | `false` | no |
 | <a name="input_eso_iam_role_name"></a> [eso\_iam\_role\_name](#input\_eso\_iam\_role\_name) | The name of the eso IAM role | `string` | `"eso-operator"` | no |
 | <a name="input_iam_additional_roles"></a> [iam\_additional\_roles](#input\_iam\_additional\_roles) | List of additional roles maps to add to the aws-auth configmap | `list(any)` | `[]` | no |
 | <a name="input_iam_additional_users"></a> [iam\_additional\_users](#input\_iam\_additional\_users) | List of additional user maps to add to the aws-auth configmap | `list(any)` | `[]` | no |

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,7 @@ module "eks" {
   cluster_version = var.cluster_version
 
   # Required as long as this module manages the aws-auth configmap
-  enable_cluster_creator_admin_permissions = true
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
 
   cluster_endpoint_private_access = true
   cluster_endpoint_public_access  = true

--- a/variables.tf
+++ b/variables.tf
@@ -58,6 +58,12 @@ variable "kms_key_administrators" {
   default     = []
 }
 
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Indicates whether or not to add the cluster creator (the identity used by Terraform) as an administrator via access entry"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # aws-auth configmap
 ################################################################################


### PR DESCRIPTION
don't add creator as admin by default to be compatible with existing clusters